### PR TITLE
Switch TypeScript build to ESM

### DIFF
--- a/lib/cb_writer.ts
+++ b/lib/cb_writer.ts
@@ -1,4 +1,4 @@
-import Writer from './writer';
+import Writer from './writer.js';
 
 /**
  * Calls callbacks when written to.

--- a/lib/emit.ts
+++ b/lib/emit.ts
@@ -1,5 +1,5 @@
-import Writer from './writer';
-import {CRecordShape, BaseShape, d2s, Shape, getReferencedRecordShapes} from './types';
+import Writer from './writer.js';
+import {CRecordShape, BaseShape, d2s, Shape, getReferencedRecordShapes} from './types.js';
 
 export function emitProxyTypeCheck(e: Emitter, w: Writer, t: Shape, tabLevel: number, dataVar: string, fieldName: string): void {
   switch(t.type) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,11 +2,11 @@
  * Library entry point. Exports public-facing interfaces.
  */
 
-import CbWriter from './cb_writer';
-import { default as Emitter } from './emit';
-import NopWriter from './nop_writer';
-import StreamWriter from './stream_writer';
-import * as Types from './types';
-import Writer from './writer';
+import CbWriter from './cb_writer.js';
+import { default as Emitter } from './emit.js';
+import NopWriter from './nop_writer.js';
+import StreamWriter from './stream_writer.js';
+import * as Types from './types.js';
+import Writer from './writer.js';
 
 export { CbWriter, Emitter, NopWriter, StreamWriter, Types, Writer };

--- a/lib/nop_writer.ts
+++ b/lib/nop_writer.ts
@@ -1,4 +1,4 @@
-import Writer from './writer';
+import Writer from './writer.js';
 
 /**
  * Does nothing.

--- a/lib/stream_writer.ts
+++ b/lib/stream_writer.ts
@@ -1,4 +1,4 @@
-import Writer from './writer';
+import Writer from './writer.js';
 
 /**
  * Writes output to a stream.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import {default as Emitter, emitProxyTypeCheck} from './emit';
+import {default as Emitter, emitProxyTypeCheck} from './emit.js';
 
 export const enum BaseShape {
   BOTTOM,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "Make TypeScript types and proxy objects from example JSON objects. Can use proxy objects to dynamically type check JSON at runtime.",
   "main": "lib/index.js",
+  "type": "module",
   "types": "lib/index",
   "scripts": {
     "prepublish": "tsc",
@@ -41,6 +42,6 @@
     "istanbul": "^1.0.0-alpha",
     "mocha": "^5.2.0",
     "npm-run-all": "^3.1.2",
-    "typescript": "^2.1.4"
+    "typescript": "^5.2.2"
   }
 }

--- a/test/collections.ts
+++ b/test/collections.ts
@@ -1,12 +1,12 @@
-import {parseEquals, parseThrows} from './common/util';
-import {PrimitiveArray} from './generated/PrimitiveArray';
-import {PrimitiveArrayProxy} from './generated/PrimitiveArrayProxy';
-import {EmptyArray} from './generated/EmptyArray';
-import {EmptyArrayProxy} from './generated/EmptyArrayProxy';
-import {MixedArray} from './generated/MixedArray';
-import {MixedArrayProxy} from './generated/MixedArrayProxy';
-import {MixedArray2} from './generated/MixedArray2';
-import {MixedArray2Proxy} from './generated/MixedArray2Proxy';
+import {parseEquals, parseThrows} from './common/util.js';
+import {PrimitiveArray} from './generated/PrimitiveArray.js';
+import {PrimitiveArrayProxy} from './generated/PrimitiveArrayProxy.js';
+import {EmptyArray} from './generated/EmptyArray.js';
+import {EmptyArrayProxy} from './generated/EmptyArrayProxy.js';
+import {MixedArray} from './generated/MixedArray.js';
+import {MixedArrayProxy} from './generated/MixedArrayProxy.js';
+import {MixedArray2} from './generated/MixedArray2.js';
+import {MixedArray2Proxy} from './generated/MixedArray2Proxy.js';
 
 describe("Collections", () => {
   it("Empty arrays", () => {

--- a/test/common/generateSamples.ts
+++ b/test/common/generateSamples.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import * as fs from 'fs';
-import * as path from 'path';
-import {StreamWriter, Emitter} from '../../lib/index';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {StreamWriter, Emitter} from '../../lib/index.js';
 
 const outdir = path.join(__dirname, "../generated");
 const sampledir = path.join(__dirname, "../samples");

--- a/test/common/util.ts
+++ b/test/common/util.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 export interface Proxy<T> {
   Parse(s: string): T;

--- a/test/large_samples.ts
+++ b/test/large_samples.ts
@@ -1,10 +1,10 @@
-import {parseEquals, parseThrows} from './common/util';
-import {WorldBank} from './generated/WorldBank';
-import {WorldBankProxy} from './generated/WorldBankProxy';
-import {GitHub} from './generated/GitHub';
-import {GitHubProxy} from './generated/GitHubProxy';
-import {TwitterStream} from './generated/TwitterStream';
-import {TwitterStreamProxy} from './generated/TwitterStreamProxy';
+import {parseEquals, parseThrows} from './common/util.js';
+import {WorldBank} from './generated/WorldBank.js';
+import {WorldBankProxy} from './generated/WorldBankProxy.js';
+import {GitHub} from './generated/GitHub.js';
+import {GitHubProxy} from './generated/GitHubProxy.js';
+import {TwitterStream} from './generated/TwitterStream.js';
+import {TwitterStreamProxy} from './generated/TwitterStreamProxy.js';
 
 describe("Large Samples", () => {
   it("World Bank", () => {

--- a/test/primitives.ts
+++ b/test/primitives.ts
@@ -1,24 +1,24 @@
-import {parseEquals, parseThrows} from './common/util';
-import {NumberProxy} from './generated/NumberProxy';
-import {NumbersProxy} from './generated/NumbersProxy';
-import {Number} from './generated/Number';
-import {Numbers} from './generated/Numbers';
-import {StringProxy} from './generated/StringProxy';
-import {String} from './generated/String';
-import {StringsProxy} from './generated/StringsProxy';
-import {Strings} from './generated/Strings';
-import {BooleanProxy} from './generated/BooleanProxy';
-import {BooleansProxy} from './generated/BooleansProxy';
-import {Boolean} from './generated/Boolean';
-import {Booleans} from './generated/Booleans';
-import {NullProxy} from './generated/NullProxy';
-import {NullsProxy} from './generated/NullsProxy';
-import {Null} from './generated/Null';
-import {Nulls} from './generated/Nulls';
-import {MaybeNumberProxy} from './generated/MaybeNumberProxy';
-import {MaybeNumber} from './generated/MaybeNumber';
-import {BooleanOrStringProxy} from './generated/BooleanOrStringProxy';
-import {BooleanOrString} from './generated/BooleanOrString';
+import {parseEquals, parseThrows} from './common/util.js';
+import {NumberProxy} from './generated/NumberProxy.js';
+import {NumbersProxy} from './generated/NumbersProxy.js';
+import {Number} from './generated/Number.js';
+import {Numbers} from './generated/Numbers.js';
+import {StringProxy} from './generated/StringProxy.js';
+import {String} from './generated/String.js';
+import {StringsProxy} from './generated/StringsProxy.js';
+import {Strings} from './generated/Strings.js';
+import {BooleanProxy} from './generated/BooleanProxy.js';
+import {BooleansProxy} from './generated/BooleansProxy.js';
+import {Boolean} from './generated/Boolean.js';
+import {Booleans} from './generated/Booleans.js';
+import {NullProxy} from './generated/NullProxy.js';
+import {NullsProxy} from './generated/NullsProxy.js';
+import {Null} from './generated/Null.js';
+import {Nulls} from './generated/Nulls.js';
+import {MaybeNumberProxy} from './generated/MaybeNumberProxy.js';
+import {MaybeNumber} from './generated/MaybeNumber.js';
+import {BooleanOrStringProxy} from './generated/BooleanOrStringProxy.js';
+import {BooleanOrString} from './generated/BooleanOrString.js';
 
 describe('Primitive Types', () => {
   it('Number', () => {

--- a/test/records.ts
+++ b/test/records.ts
@@ -1,8 +1,8 @@
-import {parseEquals, parseThrows} from './common/util';
-import {OptionalField} from './generated/OptionalField';
-import {OptionalFieldProxy} from './generated/OptionalFieldProxy';
-import {FieldNames} from './generated/FieldNames';
-import {FieldNamesProxy} from './generated/FieldNamesProxy';
+import {parseEquals, parseThrows} from './common/util.js';
+import {OptionalField} from './generated/OptionalField.js';
+import {OptionalFieldProxy} from './generated/OptionalFieldProxy.js';
+import {FieldNames} from './generated/FieldNames.js';
+import {FieldNamesProxy} from './generated/FieldNamesProxy.js';
 
 describe("Records", () => {
   it("Optional fields", () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
+        "module": "es2020",
+        "target": "es2020",
         "noImplicitAny": true,
         "noUnusedLocals": true,
         "noEmitOnError": true,
-        "moduleResolution": "node",
+        "moduleResolution": "node16",
         "alwaysStrict": true,
         "inlineSourceMap": true,
         "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
+        "module": "es2020",
+        "target": "es2020",
         "noImplicitAny": true,
         "noUnusedLocals": true,
         "noEmitOnError": true,
-        "moduleResolution": "node",
+        "moduleResolution": "node16",
         "alwaysStrict": true,
         "inlineSourceMap": true,
         "strictNullChecks": true,


### PR DESCRIPTION
## Summary
- enable ESM output by using `module` and `target` `es2020`
- set package `type` field and update TypeScript version
- adjust imports to use `.js` extension for Node ESM
- update tests to use ESM-compatible imports

## Testing
- `npm test` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496ae6d3988326b3fbb73fff64666e